### PR TITLE
[FIX] update name octave dev package

### DIFF
--- a/.github/workflows/octave_test_and_coverage.yml
+++ b/.github/workflows/octave_test_and_coverage.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -y -qq update
-        sudo apt-get -y install octave liboctave-dev
+        sudo apt-get -y install octave octave-dev
 
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the Octave development package installation from `liboctave-dev` to `octave-dev`.